### PR TITLE
require http2 in http sink

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -76,7 +76,7 @@ where
         client_builder: &mut client::Builder,
     ) -> Result<HttpClient<B>, HttpError> {
         let proxy = build_proxy_connector(tls_settings.into(), proxy_config)?;
-        let client = client_builder.build(proxy);
+        let client = client_builder.http2_only(true).build(proxy);
 
         let version = crate::get_version();
         let user_agent = HeaderValue::from_str(&format!("Vector/{}", version))

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -13,6 +13,12 @@ use http::{
     Method, Request, StatusCode, Uri,
 };
 use hyper::Body;
+
+use hyper::{
+    client,
+    client::{Client},
+};
+
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
@@ -139,7 +145,8 @@ impl GenerateConfig for HttpSinkConfig {
 impl HttpSinkConfig {
     fn build_http_client(&self, cx: &SinkContext) -> crate::Result<HttpClient> {
         let tls = TlsSettings::from_options(&self.tls)?;
-        Ok(HttpClient::new(tls, cx.proxy())?)
+        let mut cb = Client::builder().http2_only(true);
+        Ok(HttpClient::new_with_custom_client(tls, cx.proxy(), &mut cb)?)
     }
 }
 

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -14,10 +14,7 @@ use http::{
 };
 use hyper::Body;
 
-use hyper::{
-    client,
-    client::{Client},
-};
+use hyper::{client, client::Client};
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -146,7 +146,10 @@ impl HttpSinkConfig {
     fn build_http_client(&self, cx: &SinkContext) -> crate::Result<HttpClient> {
         let tls = TlsSettings::from_options(&self.tls)?;
         let mut cb = Client::builder().http2_only(true);
-        Ok(HttpClient::new_with_custom_client(tls, cx.proxy(), &mut cb)?)
+        Ok(HttpClient::new_with_custom_client(
+            tls,
+            cx.proxy(),
+            &mut cb)?)
     }
 }
 

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -145,11 +145,11 @@ impl GenerateConfig for HttpSinkConfig {
 impl HttpSinkConfig {
     fn build_http_client(&self, cx: &SinkContext) -> crate::Result<HttpClient> {
         let tls = TlsSettings::from_options(&self.tls)?;
-        let mut cb = Client::builder().http2_only(true);
         Ok(HttpClient::new_with_custom_client(
             tls,
             cx.proxy(),
-            &mut cb)?)
+            Client::builder().http2_only(true),
+        )?)
     }
 }
 

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -14,7 +14,7 @@ use http::{
 };
 use hyper::Body;
 
-use hyper::{client, client::Client};
+use hyper::client::Client;
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -145,7 +145,7 @@ impl HttpSinkConfig {
         Ok(HttpClient::new_with_custom_client(
             tls,
             cx.proxy(),
-            Client::builder().http2_only(true),
+            &mut Client::builder().http2_only(true),
         )?)
     }
 }

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -14,8 +14,6 @@ use http::{
 };
 use hyper::Body;
 
-use hyper::client::Client;
-
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
@@ -142,11 +140,7 @@ impl GenerateConfig for HttpSinkConfig {
 impl HttpSinkConfig {
     fn build_http_client(&self, cx: &SinkContext) -> crate::Result<HttpClient> {
         let tls = TlsSettings::from_options(&self.tls)?;
-        Ok(HttpClient::new_with_custom_client(
-            tls,
-            cx.proxy(),
-            &mut Client::builder().http2_only(true),
-        )?)
+        Ok(HttpClient::new(tls, cx.proxy())?)
     }
 }
 


### PR DESCRIPTION
Hacky way to turn on http2 for the http sink.